### PR TITLE
fix: check for successful clone

### DIFF
--- a/src/mac
+++ b/src/mac
@@ -56,7 +56,7 @@ clone_laptop_repository() {
         mkdir -p $laptop_repo_directory
         git clone git@github.com:ssmereka/laptop.git "$laptop_repo_directory"
 
-        if [[ ! -f "$laptop_repo_directory/mac" ]]; then
+        if [[ ! -f "$laptop_src_directory/mac" ]]; then
             echo -e "\n🔴 Error:  Failed to clone Laptop to \"$laptop_repo_directory\".\n\n\tCommand:  git clone git@github.com:ssmereka/laptop.git \"$laptop_repo_directory\""
         fi
     fi


### PR DESCRIPTION
Fixes issue where the check for a successful clone was looking for the `mac` script in the wrong location. This generated an incorrect error response after a successful clone of the Laptop repository.