### PR TITLE
fix: log messages

### DIFF
--- a/src/mac
+++ b/src/mac
@@ -407,12 +407,12 @@ update_laptop_repository() {
             log "\nSkipped pulling the latest changes from the remote Laptop repository."
             return
         else
-            log "\nStashing local changes."
+            log "\nStashing local changes.\n"
             git stash
         fi
     fi
 
-    log "Checking out the \"main\" branch and pulling changes."
+    log "\nChecking out the \"main\" branch and pulling changes.\n"
     git fetch
     git checkout main
     git pull origin main


### PR DESCRIPTION
The messages were a little hard to read, adding spaces around the "log" messages.

Before:
```
Continue without pulling the latest changes? [Y/n]? n

Stashing local changes.
Saved working directory and index state WIP on main: c7b2537 fix: updated unsaved change message (#5)
Checking out the "main" branch and pulling changes.
Already on 'main'
Your branch is up to date with 'origin/main'.
From github.com:ssmereka/laptop
 * branch            main       -> FETCH_HEAD
Already up to date.
```

After

```
Continue without pulling the latest changes? [Y/n]? n

Stashing local changes.

Saved working directory and index state WIP on main: c7b2537 fix: updated unsaved change message (#5)

Checking out the "main" branch and pulling changes.

Already on 'main'
Your branch is up to date with 'origin/main'.
From github.com:ssmereka/laptop
 * branch            main       -> FETCH_HEAD
Already up to date.
```