### PR TITLE
fix: user asdf for python, go, ruby, and node installs

### DIFF
--- a/src/.zshrc
+++ b/src/.zshrc
@@ -81,12 +81,22 @@ setopt SHARE_HISTORY
 
 # ASDF Version Manager
 # https://asdf-vm.com
-
 . $(brew --prefix asdf)/libexec/asdf.sh
+
+# Python Version Manager
+# https://github.com/pyenv/pyenv
+# ASDF python plugin uses pyenv under the hood. These are the configurations for that package manager.
+alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
+export PYENV_ROOT="$HOME/.pyenv"
+command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+
+# ASDF is currently configured to manage node, go, python, and ruby. However these plugins can
+# sometimes not be as reliable as the individual version managers. Settings are included for the
+# standard package managers should you need to use them instead of ASDF.
 
 # Node Version Manager (NVM)
 # https://github.com/nvm-sh/nvm
-
 # # Add NVM to the user's PATH.
 # export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 # # Add NVM autocompletion
@@ -95,7 +105,6 @@ setopt SHARE_HISTORY
 
 # Ruby Version Manager (RVM)
 # https://rvm.io
-
 # Add Ruby Version Manager to the user's PATH.
 # PATH_TO_RVM="$HOME/.rvm/bin"
 # if test -f "$PATH_TO_RVM"; then
@@ -103,23 +112,13 @@ setopt SHARE_HISTORY
 #     echo "Added RVM bin to the user's path \"$PATH\"."
 # fi
 
-
 # Go Version Manager (GVM)
 # https://github.com/moovweb/gvm
-
 # Add Go Version Manager to the user's PATH
-[[ -s ~/.gvm/scripts/gvm ]] && . ~/.gvm/scripts/gvm
-export GOPATH="$HOME/go"
-PATH="$GOPATH/bin:$PATH"
+# [[ -s ~/.gvm/scripts/gvm ]] && . ~/.gvm/scripts/gvm
+# export GOPATH="$HOME/go"
+# PATH="$GOPATH/bin:$PATH"
 
-
-# Python Version Manager
-# https://github.com/pyenv/pyenv
-
-alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
-export PYENV_ROOT="$HOME/.pyenv"
-command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
 
 
 ########################################

--- a/src/mac
+++ b/src/mac
@@ -142,7 +142,15 @@ configure_asdf() {
     asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
     asdf install nodejs latest
     asdf global nodejs latest
-    log "\nInstalled Node.js $(node --version)"
+    log "\nUsing Node.js version $(node --version)"
+
+    # Install the lastest version of Python using ASDF
+    # https://github.com/asdf-community/asdf-python
+    log_header "🔧 Installing Python with ASDF"
+    asdf plugin-add python
+    asdf install python latest
+    asdf global python latest
+    log "\nUsing Python version $(python --version)"
 
     # Install the latest version of Ruby using ASDF
     # https://github.com/asdf-vm/asdf-ruby
@@ -150,16 +158,19 @@ configure_asdf() {
     asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
     asdf install ruby latest
     asdf global ruby latest
-    log "\nInstalled Ruby $(ruby --version)"
+    log "\nUsing Ruby version $(ruby --version)"
 
     # Install the latest version of Go using ASDF
     # https://github.com/asdf-community/asdf-golang?tab=readme-ov-file#asdf-golang
-    # log_header "🔧 Installing Go"
-    # asdf plugin add golang https://github.com/asdf-community/asdf-golang.git
-    # asdf install golang latest
-    # asdf global golang latest
-    # log "Installed Go $(go version)"
-    
+    log_header "🔧 Installing Go"
+    asdf plugin add golang https://github.com/asdf-community/asdf-golang.git
+    # Manually set this env varible to the non default value of "false". This will force go to use
+    # the exact versoins in .tool-versions and/or .go-version files. See
+    # https://github.com/asdf-community/asdf-golang?tab=readme-ov-file#version-selection
+    export ASDF_GOLANG_MOD_VERSION_ENABLED=false && asdf install golang latest
+    export ASDF_GOLANG_MOD_VERSION_ENABLED=false && asdf global golang latest
+    go_version=$(go version)
+    log "\nUsing Go version $go_version"
 }
 
 # Create a Git configuration file with the user's GitHub information from 1Password.


### PR DESCRIPTION
Updates script to install and configure python, go, ruby, and node all with asdf. Leaves settings for managing with individual package managers in the zshrc file.