### PR TITLE
fix: adds uninstall, atuin history, and more

### DIFF
--- a/src/.zshrc
+++ b/src/.zshrc
@@ -17,6 +17,8 @@ compinit
 # Enable autocomplete for hidden (ie. dot) files.
 _comp_options+=(globdots)
 
+# Enable Atuin for managing shell history, https://atuin.sh
+eval "$(atuin init zsh)"
 
 # Enable autocomplete for 1Password CLI, 
 # https://developer.1password.com/docs/cli/reference/commands/completion/

--- a/src/.zshrc_methods
+++ b/src/.zshrc_methods
@@ -35,10 +35,8 @@ lt-help() {
   \t⏳  history \t print command history, use "history | grep <search>" to search.
   
   🧰 Tools:
-  \t👻  nvm   \t https://github.com/nvm-sh/nvm
-  \t💎  rvm   \t https://rvm.io
-  \t🐍  pyenv \t 
-  \t🦔  gvm   \t https://github.com/moovweb/gvm
+  \t🧳  asdf  \t https://asdf-vm.com
+  \t🐍  pyenv \t https://github.com/pyenv/pyenv
 
   🔄 Kubernetes:
   \t k                  \t kubectl alias

--- a/src/atuin_config.toml
+++ b/src/atuin_config.toml
@@ -1,0 +1,237 @@
+## where to store your database, default is your system data directory
+## linux/mac: ~/.local/share/atuin/history.db
+## windows: %USERPROFILE%/.local/share/atuin/history.db
+# db_path = "~/.history.db"
+
+## where to store your encryption key, default is your system data directory
+## linux/mac: ~/.local/share/atuin/key
+## windows: %USERPROFILE%/.local/share/atuin/key
+# key_path = "~/.key"
+
+## where to store your auth session token, default is your system data directory
+## linux/mac: ~/.local/share/atuin/session
+## windows: %USERPROFILE%/.local/share/atuin/session
+# session_path = "~/.session"
+
+## date format used, either "us" or "uk"
+dialect = "us"
+
+## default timezone to use when displaying time
+## either "l", "local" to use the system's current local timezone, or an offset
+## from UTC in the format of "<+|->H[H][:M[M][:S[S]]]"
+## for example: "+9", "-05", "+03:30", "-01:23:45", etc.
+timezone = "local"
+
+## enable or disable automatic sync
+auto_sync = false
+
+## enable or disable automatic update checks
+# update_check = true
+
+## address of the sync server
+# sync_address = "https://api.atuin.sh"
+
+## how often to sync history. note that this is only triggered when a command
+## is ran, so sync intervals may well be longer
+## set it to 0 to sync after every command
+# sync_frequency = "10m"
+
+## which search mode to use
+## possible values: prefix, fulltext, fuzzy, skim
+# search_mode = "fuzzy"
+
+## which filter mode to use
+## possible values: global, host, session, directory
+filter_mode = "host"
+
+## With workspace filtering enabled, Atuin will filter for commands executed
+## in any directory within a git repository tree (default: false)
+# workspaces = false
+
+## which filter mode to use when atuin is invoked from a shell up-key binding
+## the accepted values are identical to those of "filter_mode"
+## leave unspecified to use same mode set in "filter_mode"
+# filter_mode_shell_up_key_binding = "global"
+
+## which search mode to use when atuin is invoked from a shell up-key binding
+## the accepted values are identical to those of "search_mode"
+## leave unspecified to use same mode set in "search_mode"
+# search_mode_shell_up_key_binding = "fuzzy"
+
+## which style to use
+## possible values: auto, full, compact
+# style = "auto"
+
+## the maximum number of lines the interface should take up
+## set it to 0 to always go full screen
+# inline_height = 0
+
+## Invert the UI - put the search bar at the top , Default to `false`
+# invert = false
+
+## enable or disable showing a preview of the selected command
+## useful when the command is longer than the terminal width and is cut off
+# show_preview = true
+
+## what to do when the escape key is pressed when searching
+## possible values: return-original, return-query
+# exit_mode = "return-original"
+
+## possible values: emacs, subl
+# word_jump_mode = "emacs"
+
+## characters that count as a part of a word
+# word_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+## number of context lines to show when scrolling by pages
+# scroll_context_lines = 1
+
+## use ctrl instead of alt as the shortcut modifier key for numerical UI shortcuts
+## alt-0 .. alt-9
+# ctrl_n_shortcuts = false
+
+## default history list format - can also be specified with the --format arg
+# history_format = "{time}\t{command}\t{duration}"
+
+## prevent commands matching any of these regexes from being written to history.
+## Note that these regular expressions are unanchored, i.e. if they don't start
+## with ^ or end with $, they'll match anywhere in the command.
+## For details on the supported regular expression syntax, see
+## https://docs.rs/regex/latest/regex/#syntax
+# history_filter = [
+#   "^secret-cmd",
+#   "^innocuous-cmd .*--secret=.+",
+# ]
+
+## prevent commands run with cwd matching any of these regexes from being written
+## to history. Note that these regular expressions are unanchored, i.e. if they don't
+## start with ^ or end with $, they'll match anywhere in CWD.
+## For details on the supported regular expression syntax, see
+## https://docs.rs/regex/latest/regex/#syntax
+# cwd_filter = [
+#   "^/very/secret/area",
+# ]
+
+## Configure the maximum height of the preview to show.
+## Useful when you have long scripts in your history that you want to distinguish
+## by more than the first few lines.
+# max_preview_height = 4
+
+## Configure whether or not to show the help row, which includes the current Atuin
+## version (and whether an update is available), a keymap hint, and the total
+## amount of commands in your history.
+# show_help = true
+
+## Configure whether or not to show tabs for search and inspect
+# show_tabs = true
+
+## Defaults to true. This matches history against a set of default regex, and will not save it if we get a match. Defaults include
+## 1. AWS key id
+## 2. Github pat (old and new)
+## 3. Slack oauth tokens (bot, user)
+## 4. Slack webhooks
+## 5. Stripe live/test keys
+# secrets_filter = true
+
+## Defaults to true. If enabled, upon hitting enter Atuin will immediately execute the command. Press tab to return to the shell and edit.
+# This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.
+enter_accept = true
+
+## Defaults to "emacs".  This specifies the keymap on the startup of `atuin
+## search`.  If this is set to "auto", the startup keymap mode in the Atuin
+## search is automatically selected based on the shell's keymap where the
+## keybinding is defined.  If this is set to "emacs", "vim-insert", or
+## "vim-normal", the startup keymap mode in the Atuin search is forced to be
+## the specified one.
+# keymap_mode = "auto"
+
+## Cursor style in each keymap mode.  If specified, the cursor style is changed
+## in entering the cursor shape.  Available values are "default" and
+## "{blink,steady}-{block,underline,bar}".
+# keymap_cursor = { emacs = "blink-block", vim_insert = "blink-block", vim_normal = "steady-block" }
+
+# network_connect_timeout = 5
+# network_timeout = 5
+
+## Timeout (in seconds) for acquiring a local database connection (sqlite)
+# local_timeout = 5
+
+## Set this to true and Atuin will minimize motion in the UI - timers will not update live, etc.
+## Alternatively, set env NO_MOTION=true
+# prefers_reduced_motion = false
+
+[stats]
+## Set commands where we should consider the subcommand for statistics. Eg, kubectl get vs just kubectl
+# common_subcommands = [
+#   "apt",
+#   "cargo",
+#   "composer",
+#   "dnf",
+#   "docker",
+#   "git",
+#   "go",
+#   "ip",
+#   "kubectl",
+#   "nix",
+#   "nmcli",
+#   "npm",
+#   "pecl",
+#   "pnpm",
+#   "podman",
+#   "port",
+#   "systemctl",
+#   "tmux",
+#   "yarn",
+# ]
+
+## Set commands that should be totally stripped and ignored from stats
+# common_prefix = ["sudo"]
+
+## Set commands that will be completely ignored from stats
+# ignored_commands = [
+#   "cd",
+#   "ls",
+#   "vi"
+# ]
+
+[keys]
+# Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
+# scroll_exits = false
+
+[sync]
+# Enable sync v2 by default
+# This ensures that sync v2 is enabled for new installs only
+# In a later release it will become the default across the board
+records = true
+
+[preview]
+## which preview strategy to use to calculate the preview height (respects max_preview_height).
+## possible values: auto, static
+## auto: length of the selected command.
+## static: length of the longest command stored in the history.
+# strategy = "auto"
+
+[daemon]
+## Enables using the daemon to sync. Requires the daemon to be running in the background. Start it with `atuin daemon`
+# enabled = false
+
+## How often the daemon should sync in seconds
+# sync_frequency = 300
+
+## The path to the unix socket used by the daemon (on unix systems)
+## linux/mac: ~/.local/share/atuin/atuin.sock
+## windows: Not Supported
+# socket_path = "~/.local/share/atuin/atuin.sock"
+
+## Use systemd socket activation rather than opening the given path (the path must still be correct for the client)
+## linux: false
+## mac/windows: Not Supported
+# systemd_socket = false
+
+## The port that should be used for TCP on non unix systems
+# tcp_port = 8889
+
+# Theming
+# Available names are: "autumn", "marine", "" (for default).
+[theme]
+name = "marine"

--- a/src/mac
+++ b/src/mac
@@ -13,7 +13,7 @@ laptop_repo_directory="$code_directory/laptop"
 laptop_src_directory="$laptop_repo_directory/src"
 
 # Directory where local Laptop configurations are stored.
-laptop_local_directory="$HOME/.laptop"
+laptop_local_directory="$HOME/.config/laptop"
 
 # Directory where the user's custom install script is stored.
 laptop_custom_install_script="$laptop_local_directory/.laptop.local"
@@ -251,6 +251,10 @@ configure_zsh() {
     # Create custom local ZSH configuration files, overwriting it if it already exists.
     copy_file "$laptop_src_location/.zshrc_aliases" "$laptop_local_directory/.zshrc_aliases" true
     copy_file "$laptop_src_location/.zshrc_methods" "$laptop_local_directory/.zshrc_methods" true
+
+    # Create a Atuin configuration file, without overwriting the file in laptop_local_directory.
+    copy_file "$laptop_src_location/atuin_config.toml" "$laptop_local_directory/atuin_config.toml" false
+    link_file "$laptop_local_directory/atuin_config.toml" "$HOME/.config/atuin/config.toml"
 }
 
 # Copy a file from the source path to the destination path if the file 
@@ -328,7 +332,8 @@ install_apps() {
     brew 'coreutils'
     brew 'curl'
     brew 'gawk'
-    brew 'gnupg' # Install gpg
+    brew 'gnupg' # https://www.gnupg.org
+    brew 'atuin' # https://atuin.sh
 EOF
 
     log_header "🔧 Installing Applications"
@@ -431,7 +436,10 @@ update_laptop_repository() {
     popd > /dev/null
 }
 
-main() {
+
+# Command Methods
+
+install() {
     log_title "💻 Configuring your Laptop"
 
     # By default, use the remote Laptop repository source files when configuring the computer.
@@ -463,10 +471,76 @@ main() {
 
     clear_secrets
 
-    log_title "🎉 Done!"
+    log_title "🎉 Done! Open a new shell to complete the installation."
 }
 
-# Thank you for reading this script before running some strangers code!
+# Remove everything this script added during installation.
+uninstall() {
+    # TODO: This method is incomplete at the moment.
 
-# Run this script.
-main
+    log_header "🔨 Uninstalling Applications"
+
+    if brew list asdf &>/dev/null; then
+        brew uninstall asdf
+    fi
+    if brew list atuin &>/dev/null; then
+        brew uninstall atuin # https://atuin.sh
+    fi
+
+    # TODO: Ask if you want to uninstall these
+    # brew uninstall gh
+    # brew uninstall coreutils
+    # brew uninstall curl
+    # brew uninstall gawk
+    # brew uninstall gnupg # https://www.gnupg.org
+
+    log_header "🗂️ Removing Application Data"
+
+    # Remove Laptop data
+    rm -rf "$laptop_local_directory"
+
+    # Remove Atuin Application Data
+    rm -rf "$HOME/.config/atuin"
+
+    log "\n🎉 Done. Restart your shell to complete the uninstall."
+}
+
+# Interprit commandline arguments and run the appropriate methods.
+main() {
+    install_flag=false
+    uninstall_flag=false
+
+    # Check for available commands
+    for arg in "$@"; do
+        if [[ "$arg" == "uninstall" ]]; then
+            uninstall_flag=true
+            break
+        fi
+
+        if [[ "$arg" == "install" ]]; then
+            install_flag=true
+            break
+        fi
+    done
+
+    # Run the appropriate command(s)
+
+    if [[ $uninstall_flag == true ]]; then
+        uninstall
+    
+    elif [[ $install_flag == true ]]; then
+        install
+    
+    # By default, run the install command.
+    else    
+        install
+    fi
+}
+
+# Hey... Thank you for reading this script before running some strangers code.
+
+
+# Run main only if the script is executed directly; not when sourced.
+if [[ "${(%):-%N}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
Adds:
* [Atuin](https://docs.atuin.sh) for managing shell history, with sync turned off.
* Ability to source the Mac script, in preparation for testing.
* Adds a basic uninstall method that needs to be built out.

Fixes:
* Removes unavailable tools from help menu
* Moves Laptop local directory to `~/.config/laptop`.