### PR TITLE
fix: add homebrew to path

### DIFF
--- a/src/.zshrc
+++ b/src/.zshrc
@@ -2,6 +2,9 @@
 
 # The system-wide profile can be found at /etc/zshrc.
 
+# Explicitly add Homebrew to the PATH, otherwise some terminals cannot find it.
+export PATH=/opt/homebrew/bin:$PATH
+
 # Enable Homebrew autocompletion, 
 # https://formulae.brew.sh/formula/zsh-completions
 if type brew &>/dev/null; then


### PR DESCRIPTION
Some terminals, like iterm, have trouble finding homebrew unless you explicitly add it to the PATH. This PR does just that.